### PR TITLE
readme: catch missed module rename in example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-GOV.UK Frontend Jinja Client
+GOV.UK Frontend Jinja2 Client
 =============================
 
 This Python package includes classes and modules to make it easier to use the
-[GOV.UK Frontend] in your Jinja-powered Python web app.
+[GOV.UK Frontend] in your Jinja2-powered Python web app.
 
 > **NOTE**: This repository is maintained by GDS developers, but **not** the
 > GOV.UK Design System team. If you have questions or need support raise an

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Python package includes classes and modules to make it easier to use the
 Somewhere in your `app.py` (or wherever you do your app initialisation):
 
 ```
-from govuk_frontend.flask_ext import init_govuk_frontend
+from govuk_frontend_jinja.flask_ext import init_govuk_frontend
 
 init_govuk_frontend(app)
 ```


### PR DESCRIPTION
Spotted a small missed rename in an example. Also specify that we're talking about jinja**2** in prose of readme.