### PR TITLE
Add support for summary list component

### DIFF
--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -58,6 +58,11 @@ def njk_to_j2(template):
     # unless describedBy is a dictionary key (i.e. quoted or dotted).
     template = re.sub(r"""(?<!['".])describedBy""", r"nonlocal.describedBy", template)
 
+    # Issue#16: some component templates test the length of an array by trying
+    # to get an attribute `.length`. Instead we need to use the Jinja filter
+    # `length()`.
+    template = template.replace(".length", " | length")
+
     return template
 
 

--- a/tests/components/test_summary_list.py
+++ b/tests/components/test_summary_list.py
@@ -1,0 +1,469 @@
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    pytest.helpers.govuk_frontend_version_info() < (2, 5),
+    reason="requires govuk-frontend >= 2.5"
+)
+
+
+@pytest.mark.xfail(reason="differences in indentation")
+def test_summary_list(env):
+    template = env.from_string(
+"""
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  'rows': [
+    {
+      'key': {
+        'text': "Name"
+      },
+      'value': {
+        'text': "Sarah Philips"
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "name"
+          }
+        ]
+      }
+    },
+    {
+      'key': {
+        'text': "Date of birth"
+      },
+      'value': {
+        'text': "5 January 1978"
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "date of birth"
+          }
+        ]
+      }
+    },
+    {
+      'key': {
+        'text': "Contact information"
+      },
+      'value': {
+        'html': "72 Guild Street<br>London<br>SE23 6FH"
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "contact information"
+          }
+        ]
+      }
+    },
+    {
+      'key': {
+        'text': "Contact details"
+      },
+      'value': {
+        'html': '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "contact details"
+          }
+        ]
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Sarah Philips
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> name</span>
+            </a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+      <dd class="govuk-summary-list__value">
+        5 January 1978
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> date of birth</span>
+            </a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact information
+      </dt>
+      <dd class="govuk-summary-list__value">
+        72 Guild Street<br>London<br>SE23 6FH
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> contact information</span>
+            </a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact details
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> contact details</span>
+            </a>
+        </dd>
+    </div>
+</dl>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="differences in indentation")
+def test_summary_list_with_actions(env):
+    template = env.from_string(
+"""
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  'rows': [
+    {
+      'key': {
+        'text': "Name"
+      },
+      'value': {
+        'text': "Sarah Philips"
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "name"
+          }
+        ]
+      }
+    },
+    {
+      'key': {
+        'text': "Date of birth"
+      },
+      'value': {
+        'text': "5 January 1978"
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "date of birth"
+          }
+        ]
+      }
+    },
+    {
+      'key': {
+        'text': "Contact information"
+      },
+      'value': {
+        'html': "72 Guild Street<br>London<br>SE23 6FH"
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "contact information"
+          }
+        ]
+      }
+    },
+    {
+      'key': {
+        'text': "Contact details"
+      },
+      'value': {
+        'html': '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
+      },
+      'actions': {
+        'items': [
+          {
+            'href': "#",
+            'text': "Change",
+            'visuallyHiddenText': "contact details"
+          }
+        ]
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Sarah Philips
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> name</span>
+            </a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+      <dd class="govuk-summary-list__value">
+        5 January 1978
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> date of birth</span>
+            </a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact information
+      </dt>
+      <dd class="govuk-summary-list__value">
+        72 Guild Street<br>London<br>SE23 6FH
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> contact information</span>
+            </a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact details
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> contact details</span>
+            </a>
+        </dd>
+    </div>
+</dl>
+"""
+        )
+    )
+
+
+def test_summary_link_without_actions(env):
+    template = env.from_string(
+"""
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  'rows': [
+    {
+      'key': {
+        'text': "Name"
+      },
+      'value': {
+        'text': "Sarah Philips"
+      }
+    },
+    {
+      'key': {
+        'text': "Date of birth"
+      },
+      'value': {
+        'text': "5 January 1978"
+      }
+    },
+    {
+      'key': {
+        'text': "Contact information"
+      },
+      'value': {
+        'html': "72 Guild Street<br>London<br>SE23 6FH"
+      }
+    },
+    {
+      'key': {
+        'text': "Contact details"
+      },
+      'value': {
+        'html': '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Sarah Philips
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+      <dd class="govuk-summary-list__value">
+        5 January 1978
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact information
+      </dt>
+      <dd class="govuk-summary-list__value">
+        72 Guild Street<br>London<br>SE23 6FH
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact details
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>
+      </dd>
+    </div>
+</dl>
+"""
+        )
+    )
+
+
+def test_summary_link_without_borders(env):
+    template = env.from_string(
+"""
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  'rows': [
+    {
+      'key': {
+        'text': "Name"
+      },
+      'value': {
+        'text': "Sarah Philips"
+      }
+    },
+    {
+      'key': {
+        'text': "Date of birth"
+      },
+      'value': {
+        'text': "5 January 1978"
+      }
+    },
+    {
+      'key': {
+        'text': "Contact information"
+      },
+      'value': {
+        'html': "72 Guild Street<br>London<br>SE23 6FH"
+      }
+    },
+    {
+      'key': {
+        'text': "Contact details"
+      },
+      'value': {
+        'html': '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Sarah Philips
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+      <dd class="govuk-summary-list__value">
+        5 January 1978
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact information
+      </dt>
+      <dd class="govuk-summary-list__value">
+        72 Guild Street<br>London<br>SE23 6FH
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact details
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>
+      </dd>
+    </div>
+</dl>
+"""
+        )
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,10 @@ pytest_plugins = ['helpers_namespace']
 import pytest
 
 from itertools import filterfalse
+import json
 import re
 from textwrap import dedent
-from typing import Iterator, Union, TextIO
+from typing import Iterator, Union, TextIO, Tuple
 
 import jinja2
 import govuk_frontend_jinja
@@ -28,6 +29,17 @@ def normalise_whitespace(buf: Union[str, TextIO]) -> str:
     """Delete lines that are empty/contain only whitespace"""
     lines = filterfalse(IS_LINE_JUNK, readlines(buf))
     return dedent(''.join(lines)).strip()
+
+
+@pytest.helpers.register
+def govuk_frontend_version_info() -> Tuple[int, int, int]:
+    """Get the version of the govuk-frontend templates
+
+    Useful for skipping depending on whether a component
+    is available or not.
+    """
+    with open("node_modules/govuk-frontend/package.json") as package:
+        return tuple(int(v) for v in json.load(package)["version"].split("."))
 
 
 @pytest.fixture

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -42,3 +42,7 @@ def test_normalise_whitespace_can_be_imported_with_another_name():
         ==
         "What's going on?\nI don't know."
     )
+
+
+def test_govuk_frontend_version():
+    assert pytest.helpers.govuk_frontend_version_info() == (2, 4, 0)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -128,3 +128,11 @@ x({
 })
 """
     )
+
+
+def test_replaces_length_getattr_with_length_filter():
+    assert (
+        njk_to_j2("{{ params.length }}")
+        ==
+        "{{ params | length }}"
+    )


### PR DESCRIPTION
@jonheslop found that the summary list component wasn't working; this PR adds a transformation to `njk_to_j2` to fix it; it also adds tests (although these will currently be skipped because we're testing against govuk-frontend 2.4.0.