### PR TITLE
Fix flask_ext to work with Flask 1.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Add code to handle when Nunjucks template wants length of an array
 * Add tests for summary list component
 
+##  Bugfixes
+
+* Fix `flask_ext` to work with Flask 1.0.x
+
 ## 2019-08-20 version 0.2.0-alpha
 
 ### Breaking changes

--- a/govuk_frontend_jinja/flask_ext.py
+++ b/govuk_frontend_jinja/flask_ext.py
@@ -16,6 +16,8 @@ def init_govuk_frontend(app):
     >>> init_govuk_frontend(app)
     """
     app.jinja_environment = Environment
-    app.jinja_options["extensions"].append(NunjucksExtension)
-    app.jinja_options["undefined"] = NunjucksUndefined
+    jinja_options = app.jinja_options.copy()
+    jinja_options["extensions"].append(NunjucksExtension)
+    jinja_options["undefined"] = NunjucksUndefined
+    app.jinja_options = jinja_options
     return app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-datafiles
-pytest-helpers-namespace

--- a/tests/test_flask_ext.py
+++ b/tests/test_flask_ext.py
@@ -1,15 +1,14 @@
 
 import pytest
 
-from flask import Flask, render_template
+flask = pytest.importorskip("flask", reason="requires Flask")
 
 import govuk_frontend_jinja
 from govuk_frontend_jinja.flask_ext import Environment, init_govuk_frontend
 
-
 @pytest.fixture
 def app():
-    return Flask("test_flask_ext")
+    return flask.Flask("test_flask_ext")
 
 
 def test_environment_takes_app_as_first_argument(app):
@@ -38,4 +37,4 @@ def test_render_template(app, loader):
     app.jinja_loader = loader
 
     with app.app_context():
-        render_template("template.njk")
+        flask.render_template("template.njk")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@ envlist = py36
 [testenv]
 whitelist_externals = sh
 extras = Flask
-deps = -rrequirements-dev.txt
+deps =
+    pytest
+    pytest-datafiles
+    pytest-helpers-namespace
 commands =
     sh scripts/get-govuk-frontend.sh
     pytest


### PR DESCRIPTION
In Flask < 1.1.x jinja_options is an ImmutableDict, so we need to copy
it before making modifications.