### PR TITLE
Move test/dev dependencies out of tox.ini and into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,10 @@ setuptools.setup(
     ],
     extras_require={
         "Flask": ["Flask"],
+        "dev": [
+            "pytest",
+            "pytest-datafiles",
+            "pytest-helpers-namespace",
+        ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ envlist = py36
 
 [testenv]
 whitelist_externals = sh
-extras = Flask
-deps =
-    pytest
-    pytest-datafiles
-    pytest-helpers-namespace
+extras =
+    Flask
+    dev
 commands =
     sh scripts/get-govuk-frontend.sh
     pytest


### PR DESCRIPTION
This allows users to install dependencies using pip directly if they wish:

    $ pip install -e .[Flask,dev]