### PR TITLE
Fix overzealous re-escaping of Markup text by indent filter

### DIFF
--- a/tests/components/test_file_upload.py
+++ b/tests/components/test_file_upload.py
@@ -151,7 +151,6 @@ r"""
     )
 
 
-@pytest.mark.xfail(reason="autoescape required, HTML entities are being escaped")
 def test_file_upload_with_label_as_page_heading(env):
     template = env.from_string(
 """

--- a/tests/components/test_textarea.py
+++ b/tests/components/test_textarea.py
@@ -108,7 +108,6 @@ def test_textarea_with_custom_rows(env):
     )
 
 
-@pytest.mark.xfail(reason="autoescape required, HTML entities being escaped")
 def test_textarea_with_label_as_page_heading(env):
     template = env.from_string(
 """


### PR DESCRIPTION
https://trello.com/c/x2jjzXJS

Don't know if you want to apply this or leave it as an xfail, but this seems to me the way to fix it.

This includes our own copy of the upstream-fixed indent filter not yet included in a stable jinja2 release. Use this as `indent_njk` so we don't alter the behaviour of the whole application's jinja2 inadvertantly.
