### PR TITLE
handle .length and .items quirks by tagging uses with an __njk signature which is specially handled

### DIFF
--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -1,3 +1,5 @@
+import builtins
+from collections.abc import Sized
 
 import jinja2
 import jinja2.ext
@@ -12,8 +14,8 @@ def njk_to_j2(template):
     # Some component templates (such as radios) use `items` as the key of
     # an object element. However `items` is also the name of a dictionary
     # method in Python, and Jinja2 will prefer to return this attribute
-    # over the dict item.
-    template = template.replace(".items", "['items']")
+    # over the dict item. Handle specially.
+    template = re.sub(r"\.items\b", ".items__njk", template)
 
     # Some component templates (such as radios) append the loop index to a
     # string. As the loop index is an integer this causes a TypeError in
@@ -55,9 +57,9 @@ def njk_to_j2(template):
     template = re.sub(r"""(?<!['".])describedBy""", r"nonlocal.describedBy", template)
 
     # Issue#16: some component templates test the length of an array by trying
-    # to get an attribute `.length`. Instead we need to use the Jinja filter
-    # `length()`.
-    template = template.replace(".length", " | length")
+    # to get an attribute `.length`. We need to handle this specially because
+    # .length isn't a thing in python
+    template = re.sub(r"\.length\b", ".length__njk", template)
 
     # see `indent_njk`
     template = re.sub(re.escape("| indent") + r"\b", "| indent_njk", template)
@@ -182,6 +184,10 @@ class NunjucksCodeGenerator(jinja2.compiler.CodeGenerator):
         self.write(')')
 
 
+_njk_signature = "__njk"
+_builtin_function_or_method_type = type({}.keys)
+
+
 class Environment(jinja2.Environment):
     code_generator_class = NunjucksCodeGenerator
 
@@ -197,3 +203,34 @@ class Environment(jinja2.Environment):
             return path.normpath(path.join(path.dirname(parent), template))
         else:
             return template
+
+    def _handle_njk(method_name):
+        def inner(self, obj, argument):
+            if isinstance(argument, str) and argument.endswith(_njk_signature):
+                # a njk-originated access will always be assuming a dict lookup before an attr
+                final_method_name = "getitem"
+                final_argument = argument[:-len(_njk_signature)]
+            else:
+                final_argument = argument
+                final_method_name = method_name
+
+            # pleasantly surprised that super() works in this context
+            retval = builtins.getattr(super(), final_method_name)(obj, final_argument)
+
+            if argument == f"length{_njk_signature}" and isinstance(retval, jinja2.runtime.Undefined) \
+                and isinstance(obj, Sized):
+                return len(obj)
+            if isinstance(argument, str) \
+                and argument.endswith(_njk_signature) \
+                and isinstance(retval, _builtin_function_or_method_type):
+                # the lookup has probably gone looking for attributes and found a builtin method. because
+                # any njk-originated lookup will have been made to prefer dict lookups over attributes, we
+                # can be fairly sure there isn't a dict key matching this - so we should just call this a
+                # failure.
+                return self.undefined(obj=obj, name=final_argument)
+            return retval
+        return inner
+
+    getitem = _handle_njk("getitem")
+
+    getattr = _handle_njk("getattr")

--- a/tests/components/date_input/test_date_input.py
+++ b/tests/components/date_input/test_date_input.py
@@ -26,7 +26,6 @@ def test_date_input_with_error_on_year_input(env, similar, template, expected):
     assert similar(template.render(), expected)
 
 
-@pytest.mark.xfail(reason="attempting to access params.items")
 def test_date_input_with_default_items(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -15,7 +15,7 @@ def test_replaces_items_getattr_with_getitem():
         )
         ==
 """
-{% for item in params['items'] %}
+{% for item in params.items__njk %}
   item
 {% endfor %}
 """
@@ -115,12 +115,4 @@ x({
     'describedBy': nonlocal.describedBy,
 })
 """
-    )
-
-
-def test_replaces_length_getattr_with_length_filter():
-    assert (
-        njk_to_j2("{{ params.length }}")
-        ==
-        "{{ params | length }}"
     )


### PR DESCRIPTION
https://trello.com/c/x2jjzXJS

Custom implementations of the `Environment`'s `getitem` and `getattr` are used to detect these and attempt to take the best action when either of these are used. We limit this to just lookups with an `__njk` signature because we don't want to alter the behaviour of *all* of an app's jinja, and
unfortunately it's not possible to switch `Environment`s as jinja enters into an `.njk` file. So we need to specially tag those `.length` and `.items` accesses that originated from an njk file in the preprocess step.

This is the only way I could think of reliably fixing `test_date_input_with_default_items`. The issue with this test is how `components/date-input/template.njk` assigns the result of the `params.items` lookup to a variable and then iterates over that later. This way of handling these lookups seems to me like it would be much more reliable than pure string replacement.