### PR TITLE
NunjucksCodeGenerator, a subclass that optionally behaves like nunjucks for inline conditionals

### DIFF
--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -21,11 +21,6 @@ def njk_to_j2(template):
     # converts integers to strings.
     template = template.replace("+ loop.index", "~ loop.index")
 
-    # Some component templates (such as radios and character-count) use an
-    # inline if-expression without an else statement to assemble a CSS
-    # class string.
-    template = re.sub(r"\b(.+) if \1(?! else)", r"\1 if \1 else ''", template)
-
     # Nunjucks uses elseif, Jinja uses elif
     template = template.replace("elseif", "elif")
 

--- a/tests/components/test_character_count.py
+++ b/tests/components/test_character_count.py
@@ -2,7 +2,6 @@
 import pytest
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
 def test_character_count(env):
     template = env.from_string(
 """
@@ -42,7 +41,7 @@ def test_character_count(env):
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+@pytest.mark.xfail(reason="overzealous escaping")
 def test_character_count_with_hint(env):
     template = env.from_string(
 """
@@ -89,7 +88,6 @@ def test_character_count_with_hint(env):
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
 def test_character_count_with_default_value(env):
     template = env.from_string(
 """
@@ -183,7 +181,6 @@ NW1 6XE
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
 def test_charcter_count_with_custom_rows(env):
     template = env.from_string(
 """
@@ -224,7 +221,7 @@ def test_charcter_count_with_custom_rows(env):
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+@pytest.mark.xfail(reason="overzealous escaping")
 def test_character_count_with_label_as_page_heading(env):
     template = env.from_string(
 """
@@ -268,7 +265,6 @@ def test_character_count_with_label_as_page_heading(env):
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
 def test_character_count_with_word_count(env):
     template = env.from_string(
 """
@@ -309,7 +305,6 @@ def test_character_count_with_word_count(env):
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
 def test_character_count_with_threshold(env):
     template = env.from_string(
 """

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -40,20 +40,6 @@ def test_replaces_add_loop_index_with_concatenate():
     )
 
 
-@pytest.mark.parametrize(
-    ("input, expected_output"),
-    (
-        ("{% ' ' + item if item %}", "{% ' ' + item if item else '' %}"),
-        ("{% ' ' + (item if item) %}", "{% ' ' + (item if item else '') %}"),
-        pytest.param("{% 'hello ' + (' world' if item) %}", "{% 'hello ' + (' world' if item else '') %}", marks=pytest.mark.xfail),
-        ("{% ' ' + item if item else '' %}", "{% ' ' + item if item else '' %}"),
-        ("{% ' ' + (item if item else '') %}", "{% ' ' + (item if item else '') %}"),
-    ),
-)
-def test_adds_else_statement_to_inline_if_expressions(input, expected_output):
-    assert njk_to_j2(input) == expected_output
-
-
 def test_quotes_dictionary_keys():
     assert (
         njk_to_j2(


### PR DESCRIPTION
Seems I forgot to create the PR for this one on friday. You're gonna love this one, but I think struggle to achieve its equivalent with a string replacement approach...

https://trello.com/c/x2jjzXJS

Note we don't wrap our `visit_CondExpr` method in their `@optimizeconst` decorator - it would just be another potentially fragile symbol to rely on from deep inside jinja and we can cope without its optimization in the rare case it doesn't just get forwarded on as a supercall anyway.