### PR TITLE
Enable autoescaping for Nunjucks templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### New features
+
+* Enable autoescaping for Nunjucks templates in Flask
+
 ## 2019-09-27 version 0.4.0-alpha
 
 ### New features

--- a/govuk_frontend_jinja/flask_ext.py
+++ b/govuk_frontend_jinja/flask_ext.py
@@ -1,5 +1,6 @@
 
 from flask.templating import Environment as FlaskEnvironment
+from jinja2 import select_autoescape
 from govuk_frontend_jinja.templates import Environment as NunjucksEnvironment
 from govuk_frontend_jinja.templates import NunjucksExtension, NunjucksUndefined
 
@@ -16,6 +17,7 @@ def init_govuk_frontend(app):
     >>> init_govuk_frontend(app)
     """
     app.jinja_environment = Environment
+    app.select_jinja_autoescape = select_autoescape(("html", "htm", "xml", "xhtml", "njk"))
     jinja_options = app.jinja_options.copy()
     jinja_options["extensions"].append(NunjucksExtension)
     jinja_options["undefined"] = NunjucksUndefined

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,11 @@ def loader(govuk_frontend):
 @pytest.fixture
 def env(loader):
     return govuk_frontend_jinja.Environment(
-        loader=loader, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True
+        loader=loader,
+        autoescape=True,
+        keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True,
     )
 
 

--- a/tests/page_template/test_page_template.py
+++ b/tests/page_template/test_page_template.py
@@ -7,7 +7,11 @@ import govuk_frontend_jinja
 def env(loader):
     return govuk_frontend_jinja.Environment(
         # for some reason the page_template tests only pass with trim_blocks=False
-        loader=loader, keep_trailing_newline=True, trim_blocks=False, lstrip_blocks=True,
+        loader=loader,
+        autoescape=True,
+        keep_trailing_newline=True,
+        trim_blocks=False,
+        lstrip_blocks=True,
     )
 
 

--- a/tests/test_flask_ext.py
+++ b/tests/test_flask_ext.py
@@ -3,6 +3,8 @@ import pytest
 
 flask = pytest.importorskip("flask", reason="requires Flask")
 
+import jinja2
+
 import govuk_frontend_jinja
 from govuk_frontend_jinja.flask_ext import Environment, init_govuk_frontend
 
@@ -38,3 +40,19 @@ def test_init_govuk_frontend(app):
 def test_render_template(app):
     with app.app_context():
         flask.render_template("template.njk")
+
+
+def test_autoescape_is_enabled_for_njk_files_by_default(app):
+    loader = jinja2.DictLoader({"test.njk": "{{ text }}"})
+    app.jinja_loader = loader
+
+    with app.app_context():
+        assert flask.render_template("test.njk", text="<script>") == "&lt;script&gt;"
+
+
+def test_autoescape_is_enabled_for_njk_files_by_default(app):
+    loader = jinja2.DictLoader({"test.njk": "{% autoescape on %}{{ text }}{% endautoescape %}"})
+    app.jinja_loader = loader
+
+    with app.app_context():
+        assert flask.render_template("test.njk", text="<script>") == "<script>"

--- a/tests/test_flask_ext.py
+++ b/tests/test_flask_ext.py
@@ -7,17 +7,20 @@ import govuk_frontend_jinja
 from govuk_frontend_jinja.flask_ext import Environment, init_govuk_frontend
 
 @pytest.fixture
-def app():
-    return flask.Flask("test_flask_ext")
+def app(loader):
+    app = flask.Flask("test_flask_ext")
+    init_govuk_frontend(app)
+    app.jinja_loader = loader
+    return app
 
 
-def test_environment_takes_app_as_first_argument(app):
+def test_environment_takes_app_as_first_argument():
+    app = flask.Flask("test_flask_ext")
     env = Environment(app)
     assert env.app == app
 
 
 def test_init_govuk_frontend(app):
-    init_govuk_frontend(app)
     env = app.jinja_env
 
     assert (
@@ -32,9 +35,6 @@ def test_init_govuk_frontend(app):
     )
 
 
-def test_render_template(app, loader):
-    init_govuk_frontend(app)
-    app.jinja_loader = loader
-
+def test_render_template(app):
     with app.app_context():
         flask.render_template("template.njk")


### PR DESCRIPTION
Ticket: https://trello.com/c/isyW25Fl/63-enable-fix-autoescaping-for-nunjucks-macros-in-frontends

Also closes issue https://github.com/alphagov/govuk-frontend-jinja/issues/6

We want to make sure that input from users is made safe by being escaped; this PR enables autoescaping in the Flask extension by default, by overriding its default autoescape selector to also include `njk` files.

We also explicitly enable autoescaping for our tests, so we can feel sure that this change won't break everything.