### PR TITLE
Release v0.5.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## Unreleased
+## 2019-10-29 version 0.5.0-alpha
 
 ### New features
 
-* Enable autoescaping for Nunjucks templates in Flask
+* Enable autoescaping for Nunjucks templates in Flask ([#37](https://github.com/alphagov/govuk-frontend-jinja/pull/37))
+
+### Bugfixes
+
+* We have 100% coverage for components in GOV.UK Design System v2.13.0! :raised_hands: ([#3](https://github.com/alphagov/govuk-frontend-jinja/issues/3))
+* Fix tests for page template ([#32](https://github.com/alphagov/govuk-frontend-jinja/pull/32))
+* Fix some instances where Jinja was unable to resolve `params.items` ([#24](https://github.com/alphagov/govuk-frontend-jinja/pull/24))
 
 ## 2019-09-27 version 0.4.0-alpha
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="0.4.0-alpha",
+    version="0.5.0-alpha",
     author="Laurence de Bruxelles",
     author_email="author@example.com",
     description="Tools to use the GOV.UK Design System with Jinja-powered Python apps",

--- a/tests/components/character_count/test_character_count.py
+++ b/tests/components/character_count/test_character_count.py
@@ -1,12 +1,8 @@
-import pytest
-
-
 def test_character_count(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)
 
 
-@pytest.mark.xfail(reason="overzealous escaping")
 def test_character_count_with_hint(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)

--- a/tests/components/textarea/test_textarea.py
+++ b/tests/components/textarea/test_textarea.py
@@ -1,7 +1,3 @@
-import pytest
-
-
-@pytest.mark.xfail(reason="apostrophe not escaped")
 def test_textarea(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)


### PR DESCRIPTION
## 2019-10-29 version 0.5.0-alpha

### New features

* Enable autoescaping for Nunjucks templates in Flask ([#37](https://github.com/alphagov/govuk-frontend-jinja/pull/37))

### Bugfixes

* We have 100% coverage for components in GOV.UK Design System v2.13.0! :raised_hands: ([#3](https://github.com/alphagov/govuk-frontend-jinja/issues/3))
* Fix tests for page template ([#32](https://github.com/alphagov/govuk-frontend-jinja/pull/32))
* Fix some instances where Jinja was unable to resolve `params.items` ([#24](https://github.com/alphagov/govuk-frontend-jinja/pull/24))