### PR TITLE
Fix bug in Flask extension where indent_njk was not available

### DIFF
--- a/govuk_frontend_jinja/flask_ext.py
+++ b/govuk_frontend_jinja/flask_ext.py
@@ -5,7 +5,7 @@ from govuk_frontend_jinja.templates import Environment as NunjucksEnvironment
 from govuk_frontend_jinja.templates import NunjucksExtension, NunjucksUndefined
 
 
-class Environment(FlaskEnvironment, NunjucksEnvironment):
+class Environment(NunjucksEnvironment, FlaskEnvironment):
     pass
 
 

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -191,10 +191,10 @@ _builtin_function_or_method_type = type({}.keys)
 class Environment(jinja2.Environment):
     code_generator_class = NunjucksCodeGenerator
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         kwargs.setdefault("extensions", [NunjucksExtension])
         kwargs.setdefault("undefined", NunjucksUndefined)
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
         self.filters["indent_njk"] = indent_njk
 
     def join_path(self, template, parent):

--- a/tests/test_flask_ext.py
+++ b/tests/test_flask_ext.py
@@ -35,6 +35,7 @@ def test_init_govuk_frontend(app):
         in
         env.extensions
     )
+    assert "indent_njk" in env.filters
 
 
 def test_render_template(app):


### PR DESCRIPTION
This PR fixes issue #40.

The use of multiple inheritance wasn't working because `govuk_frontend_jinja.Environment.__init__`'s call signature didn't accept positional arguments; fixing this bug allowed the proper method resolution order to be specified, and now the init function that adds `indent_njk` gets called as expected.

The lesson here is probably "don't use multiple inheritance", but oh well 🤷‍♂ 