### PR TITLE
Release v0.5.2-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2020-08-03 version 0.5.2-alpha
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fix links in README (thanks [@dalepotter](https://gitbhub.com/dalepotter)!) ([#34](https://github.com/alphagov/govuk-frontend-jinja/pull/34))
 
+* You can now use the Nunjucks strict equality operator `===` in templates ([#50](https://github.com/alphagov/govuk-frontend-jinja/pull/50))
+
 ## 2019-11-01 version 0.5.1-alpha
 
 ### Bugfixes

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="0.5.1-alpha",
+    version="0.5.2-alpha",
     author="Laurence de Bruxelles",
     author_email="author@example.com",
     description="Tools to use the GOV.UK Design System with Jinja-powered Python apps",


### PR DESCRIPTION
### Bugfixes

* Fix links in README (thanks [@dalepotter](https://gitbhub.com/dalepotter)!) ([#34](https://github.com/alphagov/govuk-frontend-jinja/pull/34))

* You can now use the Nunjucks strict equality operator `===` in templates ([#50](https://github.com/alphagov/govuk-frontend-jinja/pull/50))