### PR TITLE
Add fix for summary list variable set within loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## Unreleased
+
+### Bugfixes
+
+* You can now use summary lists with actions (thanks [@domoscargin](https://github.com/domoscargin)!) ([#52](https://github.com/alphagov/govuk-frontend-jinja/pull/52))
+
 ## 2020-08-03 version 0.5.2-alpha
 
 ### Bugfixes
 
-* Fix links in README (thanks [@dalepotter](https://gitbhub.com/dalepotter)!) ([#34](https://github.com/alphagov/govuk-frontend-jinja/pull/34))
+* Fix links in README (thanks [@dalepotter](https://github.com/dalepotter)!) ([#34](https://github.com/alphagov/govuk-frontend-jinja/pull/34))
 
 * You can now use the Nunjucks strict equality operator `===` in templates ([#50](https://github.com/alphagov/govuk-frontend-jinja/pull/50))
 

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -56,6 +56,12 @@ def njk_to_j2(template):
     # Change any references to describedBy to be nonlocal.describedBy,
     # unless describedBy is a dictionary key (i.e. quoted or dotted).
     template = re.sub(r"""(?<!['".])describedBy""", r"nonlocal.describedBy", template)
+    # govukSummaryList
+    template = re.sub(r"""^([ ]*)({% set anyRowHasActions = false %})""",
+                      r"\1{%- set nonlocal = namespace() -%}\n\1\2",
+                      template,
+                      flags=re.M)
+    template = re.sub(r"""(?<!['".])anyRowHasActions""", r"nonlocal.anyRowHasActions", template)
 
     # Issue#16: some component templates test the length of an array by trying
     # to get an attribute `.length`. We need to handle this specially because

--- a/tests/components/summary_list/test_summary_list.py
+++ b/tests/components/summary_list/test_summary_list.py
@@ -16,6 +16,11 @@ def test_summary_list_with_actions(env, similar, template, expected):
     assert similar(template.render(), expected)
 
 
+def test_summary_list_with_some_actions(env, similar, template, expected):
+    template = env.from_string(template)
+    assert similar(template.render(), expected)
+
+
 def test_summary_list_without_actions(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)

--- a/tests/components/summary_list/test_summary_list_with_some_actions.t.html
+++ b/tests/components/summary_list/test_summary_list_with_some_actions.t.html
@@ -1,0 +1,44 @@
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  "rows": [
+    {
+      "key": {
+        "text": "Name"
+      },
+      "value": {
+        "text": "Firstname Lastname"
+      },
+      "actions": {
+        "items": [
+          {
+            "href": "#",
+            "text": "Edit",
+            "visuallyHiddenText": "name"
+          },
+          {
+            "href": "#",
+            "text": "Delete",
+            "visuallyHiddenText": "name"
+          }
+        ]
+      }
+    },
+    {
+      "key": {
+        "text": "Date of birth"
+      },
+      "value": {
+        "text": "13/08/1980"
+      }
+    },
+    {
+      "key": {
+        "text": "Contact information"
+      },
+      "value": {
+        "html": "<p class=\"govuk-body\">\n  email@email.com\n</p>\n<p class=\"govuk-body\">\n  Address line 1<br>\n  Address line 2<br>\n  Address line 3<br>\n  Address line 4<br>\n  Address line 5\n</p>\n"
+      }
+    }
+  ]
+}) }}

--- a/tests/components/summary_list/test_summary_list_with_some_actions.x.html
+++ b/tests/components/summary_list/test_summary_list_with_some_actions.x.html
@@ -1,0 +1,53 @@
+<dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Firstname Lastname
+      </dd>
+        <dd class="govuk-summary-list__actions">
+            <ul class="govuk-summary-list__actions-list">
+                <li class="govuk-summary-list__actions-list-item">
+                  <a class="govuk-link" href="#">
+                      Edit<span class="govuk-visually-hidden"> name</span>
+                  </a>
+                </li>
+                <li class="govuk-summary-list__actions-list-item">
+                  <a class="govuk-link" href="#">
+                      Delete<span class="govuk-visually-hidden"> name</span>
+                  </a>
+                </li>
+            </ul>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+      <dd class="govuk-summary-list__value">
+        13/08/1980
+      </dd>
+        
+        <span class="govuk-summary-list__actions"></span>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Contact information
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          email@email.com
+        </p>
+        <p class="govuk-body">
+          Address line 1<br>
+          Address line 2<br>
+          Address line 3<br>
+          Address line 4<br>
+          Address line 5
+        </p>
+      </dd>
+        
+        <span class="govuk-summary-list__actions"></span>
+    </div>
+</dl>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -116,3 +116,27 @@ x({
 })
 """
     )
+
+
+def test_adds_nonlocal_namespace_if_template_includes_anyRowHasActions():
+    template = """{% set anyRowHasActions = false %}"""
+    assert "{%- set nonlocal = namespace() -%}" in njk_to_j2(template)
+
+
+def test_patches_anyRowHasActions_to_set_nonlocal():
+    template = \
+"""
+{% set anyRowHasActions = false %}
+{% set anyRowHasActions = true if row.actions.items else anyRowHasActions %}
+{% elseif anyRowHasActions %}
+"""
+    assert (
+        njk_to_j2(template)
+        ==
+"""
+{%- set nonlocal = namespace() -%}
+{% set nonlocal.anyRowHasActions = false %}
+{% set nonlocal.anyRowHasActions = true if row.actions.items__njk else nonlocal.anyRowHasActions %}
+{% elif nonlocal.anyRowHasActions %}
+"""
+    )


### PR DESCRIPTION
govukSummaryList creates the `anyRowHasActions` variable outside a loop and changes it within a loop.

https://github.com/alphagov/govuk-frontend/blob/844a51e07c643cec84c6425a8cbda568261c78c5/src/govuk/components/summary-list/template.njk#L10-L14

Jinja doesn't support this as is, so this adds namespacing for it.
