### PR TITLE
Add support for character count int concatenation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,75 @@
+{
+  "exclude": {
+    "files": "package-lock.json",
+    "lines": null
+  },
+  "generated_at": "2020-09-07T13:08:09Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "scripts/get-govuk-frontend.sh": [
+      {
+        "hashed_secret": "45973f7e17da2af67b574d9f7ba1defb14b8c6b4",
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bugfixes
+
+* Fix int concatenation error in v3.5.0+ versions of Character Count ([#54](https://github.com/alphagov/govuk-frontend-jinja/pull/54))
+
 ## 2020-08-6 version 0.5.3-alpha
 
 ### Bugfixes

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -24,6 +24,15 @@ def njk_to_j2(template):
     # converts integers to strings.
     template = template.replace("+ loop.index", "~ loop.index")
 
+    # The Character Count component in version 3 concatenates the word count
+    # with the hint text. As the word count is an integer this causes a 
+    # TypeError in Python. Jinja2 has an operator `~` for string
+    # concatenation that converts integers to strings.
+    template = template.replace(
+        "+ (params.maxlength or params.maxwords) +",
+        "~ (params.maxlength or params.maxwords) ~"
+    )
+
     # Nunjucks uses elseif, Jinja uses elif
     template = template.replace("elseif", "elif")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="0.5.3-alpha",
+    version="0.5.4-alpha",
     author="Laurence de Bruxelles",
     author_email="author@example.com",
     description="Tools to use the GOV.UK Design System with Jinja-powered Python apps",

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -39,6 +39,22 @@ def test_replaces_add_loop_index_with_concatenate():
 """
     )
 
+def test_replaces_add_max_words_with_concatenate():
+    assert (
+        njk_to_j2(
+"""
+{{ macro({
+  text: 'You can enter up to ' + (params.maxlength or params.maxwords) + (' words' if params.maxwords else ' characters')
+}) }}
+"""
+        )
+        ==
+"""
+{{ macro({
+  'text': 'You can enter up to ' ~ (params.maxlength or params.maxwords) ~ (' words' if params.maxwords else ' characters')
+}) }}
+"""
+    )
 
 def test_quotes_dictionary_keys():
     assert (


### PR DESCRIPTION
As of 3.5.0 of GOV.UK Frontend, the Character Count component includes an int concatenation in the hint: https://github.com/alphagov/govuk-frontend/blob/befc348ab6aec7c25c61c71ebf363a6b3bb36949/src/govuk/components/character-count/template.njk#L30

This is causing errors updating Briefs FE to v3, so this is a quick fix for it, before we switch over to the Land Registry govuk-frontend-jinja.