### PR TITLE
Add items() to item.attributes

### DIFF
--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -55,6 +55,14 @@ def njk_to_j2(template):
     template = template.replace("for attribute, value in params.attributes",
                                 "for attribute, value in params.attributes.items()")
 
+    # The attributes field of a govukCheckbox item is supposed to be a dictionary,
+    # and in the template for the checkbox component the keys and values are iterated.
+    # In Python the default iterator for a dict is .keys(), but we want .items().
+    # This only works because our undefined implements .items().
+    template = template.replace("for attribute, value in item.attributes",
+                                "for attribute, value in item.attributes.items()")
+
+
     # Some templates try to set a variable in an outer block, which is not
     # supported in Jinja. We create a namespace in those templates to get
     # around this.

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -92,6 +92,14 @@ def test_patches_iteration_of_params_attributes():
     )
 
 
+def test_patches_iteration_of_item_attributes():
+    assert (
+        njk_to_j2("{%- for attribute, value in item.attributes %}{% endfor -%}")
+        ==
+        "{%- for attribute, value in item.attributes.items() %}{% endfor -%}"
+    )
+
+
 @pytest.mark.parametrize("template", (
     """\n    {% set describedBy = "" %}""",
     """\n    {% set describedBy = params.describedBy if params.describedBy else "" %}""",


### PR DESCRIPTION
govukCheckboxes includes a `for attribute, value in item.attributes` iteration which fails.

This can be fixed by using `.items()` instead of the Python default `.keys()`