### PR TITLE
Add namespacing for isConditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bugfixes
+
+* Fix support for conditional content on Checkboxes and Radios ([#58](https://github.com/alphagov/govuk-frontend-jinja/pull/58))
+
 ## 2020-09-25 version 0.5.5-alpha
 
 ### Bugfixes

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -79,11 +79,9 @@ def njk_to_j2(template):
                       template,
                       flags=re.M)
     template = re.sub(r"""(?<!['".])anyRowHasActions""", r"nonlocal.anyRowHasActions", template)
-    # govukRadios
-    template = re.sub(r"""^([ ]*)({% set isConditional = false %})""",
-                      r"\1{%- set nonlocal = namespace() -%}\n\1\2",
-                      template,
-                      flags=re.M)
+    # govukRadios and govukCheckboxes
+    # Since both of these templates set describedBy before isConditional, we can use
+    # the existing nonlocal.
     template = re.sub(r"""(?<!['".])isConditional""", r"nonlocal.isConditional", template)
 
     # Issue#16: some component templates test the length of an array by trying

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -79,6 +79,12 @@ def njk_to_j2(template):
                       template,
                       flags=re.M)
     template = re.sub(r"""(?<!['".])anyRowHasActions""", r"nonlocal.anyRowHasActions", template)
+    # govukRadios
+    template = re.sub(r"""^([ ]*)({% set isConditional = false %})""",
+                      r"\1{%- set nonlocal = namespace() -%}\n\1\2",
+                      template,
+                      flags=re.M)
+    template = re.sub(r"""(?<!['".])isConditional""", r"nonlocal.isConditional", template)
 
     # Issue#16: some component templates test the length of an array by trying
     # to get an attribute `.length`. We need to handle this specially because

--- a/tests/components/checkboxes/test_checkboxes.py
+++ b/tests/components/checkboxes/test_checkboxes.py
@@ -28,6 +28,11 @@ def test_checkboxes_with_a_medium_legend(env, similar, template, expected):
     assert similar(template.render(), expected)
 
 
+def test_checkboxes_with_a_conditional(env, similar, template, expected):
+    template = env.from_string(template)
+    assert similar(template.render(), expected)
+
+
 def test_checkboxes_without_fieldset(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)

--- a/tests/components/checkboxes/test_checkboxes_with_a_conditional.t.html
+++ b/tests/components/checkboxes/test_checkboxes_with_a_conditional.t.html
@@ -1,0 +1,47 @@
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "input/macro.njk" import govukInput %}
+
+{% set emailHtml %}
+{{ govukInput({
+  "id": "contact-by-email",
+  "name": "contact-by-email",
+  "type": "email",
+  "spellcheck": false,
+  "classes": "govuk-!-width-one-third",
+  "label": {
+    "text": "Email address"
+  }
+}) }}
+{% endset -%}
+
+{{ govukCheckboxes({
+  "idPrefix": "contact",
+  "name": "contact",
+  "fieldset": {
+    "legend": {
+      "text": "How would you prefer to be contacted?",
+      "isPageHeading": true,
+      "classes": "govuk-fieldset__legend--l"
+    }
+  },
+  "hint": {
+    "text": "Select one option."
+  },
+  "items": [
+    {
+      "value": "email",
+      "text": "Email",
+      "conditional": {
+        "html": emailHtml
+      }
+    },
+    {
+      "value": "phone",
+      "text": "Phone",
+    },
+    {
+      "value": "text",
+      "text": "Text message",
+    }
+  ]
+}) }}

--- a/tests/components/checkboxes/test_checkboxes_with_a_conditional.x.html
+++ b/tests/components/checkboxes/test_checkboxes_with_a_conditional.x.html
@@ -1,0 +1,38 @@
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      How would you prefer to be contacted?
+    </h1>
+  </legend>
+  <span id="contact-hint" class="govuk-hint">
+    Select one option.
+  </span>
+  <div class="govuk-checkboxes" data-module="checkboxes">
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="contact-1" name="contact" type="checkbox" value="email" data-aria-controls="conditional-contact-1">
+      <label class="govuk-label govuk-checkboxes__label" for="contact-1">
+        Email
+      </label>    </div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional-contact-1">
+        <div class="govuk-form-group">
+  <label class="govuk-label" for="contact-by-email">
+    Email address
+  </label>
+  <input class="govuk-input govuk-!-width-one-third" id="contact-by-email" name="contact-by-email" type="email">
+</div>
+      </div>
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="contact-2" name="contact" type="checkbox" value="phone">
+      <label class="govuk-label govuk-checkboxes__label" for="contact-2">
+        Phone
+      </label>    </div>
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="contact-3" name="contact" type="checkbox" value="text">
+      <label class="govuk-label govuk-checkboxes__label" for="contact-3">
+        Text message
+      </label>    </div>
+  </div>
+
+</fieldset>
+</div>

--- a/tests/components/radios/test_radios.py
+++ b/tests/components/radios/test_radios.py
@@ -23,6 +23,11 @@ def test_radios_with_a_divider(env, similar, template, expected):
     assert similar(template.render(), expected)
 
 
+def test_radios_with_a_conditional(env, similar, template, expected):
+    template = env.from_string(template)
+    assert similar(template.render(), expected)
+
+
 def test_radios_with_hints_on_items(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)

--- a/tests/components/radios/test_radios_with_a_conditional.t.html
+++ b/tests/components/radios/test_radios_with_a_conditional.t.html
@@ -1,0 +1,47 @@
+{% from "radios/macro.njk" import govukRadios %}
+{% from "input/macro.njk" import govukInput %}
+
+{% set emailHtml %}
+{{ govukInput({
+  "id": "contact-by-email",
+  "name": "contact-by-email",
+  "type": "email",
+  "spellcheck": false,
+  "classes": "govuk-!-width-one-third",
+  "label": {
+    "text": "Email address"
+  }
+}) }}
+{% endset -%}
+
+{{ govukRadios({
+  "idPrefix": "contact",
+  "name": "contact",
+  "fieldset": {
+    "legend": {
+      "text": "How would you prefer to be contacted?",
+      "isPageHeading": true,
+      "classes": "govuk-fieldset__legend--l"
+    }
+  },
+  "hint": {
+    "text": "Select one option."
+  },
+  "items": [
+    {
+      "value": "email",
+      "text": "Email",
+      "conditional": {
+        "html": emailHtml
+      }
+    },
+    {
+      "value": "phone",
+      "text": "Phone",
+    },
+    {
+      "value": "text",
+      "text": "Text message",
+    }
+  ]
+}) }}

--- a/tests/components/radios/test_radios_with_a_conditional.x.html
+++ b/tests/components/radios/test_radios_with_a_conditional.x.html
@@ -1,0 +1,38 @@
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      How would you prefer to be contacted?
+    </h1>
+  </legend>
+  <span id="contact-hint" class="govuk-hint">
+    Select one option.
+  </span>
+  <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="contact-1" name="contact" type="radio" value="email" data-aria-controls="conditional-contact-1">
+      <label class="govuk-label govuk-radios__label" for="contact-1">
+        Email
+      </label>    </div>
+      <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-contact-1">
+        <div class="govuk-form-group">
+  <label class="govuk-label" for="contact-by-email">
+    Email address
+  </label>
+  <input class="govuk-input govuk-!-width-one-third" id="contact-by-email" name="contact-by-email" type="email">
+</div>
+      </div>
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="contact-2" name="contact" type="radio" value="phone">
+      <label class="govuk-label govuk-radios__label" for="contact-2">
+        Phone
+      </label>    </div>
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="contact-3" name="contact" type="radio" value="text">
+      <label class="govuk-label govuk-radios__label" for="contact-3">
+        Text message
+      </label>    </div>
+  </div>
+
+</fieldset>
+</div>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -164,3 +164,29 @@ def test_patches_anyRowHasActions_to_set_nonlocal():
 {% elif nonlocal.anyRowHasActions %}
 """
     )
+
+
+def test_adds_nonlocal_namespace_if_template_includes_isConditional():
+    template = """{% set isConditional = false %}"""
+    assert "{%- set nonlocal = namespace() -%}" in njk_to_j2(template)
+
+
+def test_patches_isConditional_to_set_nonlocal():
+    template = \
+"""
+{% set isConditional = false %}
+{% set isConditional = true %}
+{%- if isConditional %} data-module="radios"{% endif -%}>
+{%- if isConditional %} govuk-radios--conditional{% endif -%}
+"""
+    assert (
+        njk_to_j2(template)
+        ==
+"""
+{%- set nonlocal = namespace() -%}
+{% set nonlocal.isConditional = false %}
+{% set nonlocal.isConditional = true %}
+{%- if nonlocal.isConditional %} data-module="radios"{% endif -%}>
+{%- if nonlocal.isConditional %} govuk-radios--conditional{% endif -%}
+"""
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -167,7 +167,9 @@ def test_patches_anyRowHasActions_to_set_nonlocal():
 
 
 def test_adds_nonlocal_namespace_if_template_includes_isConditional():
-    template = """{% set isConditional = false %}"""
+    # govukRadios and govukCheckboxes both set describedBy before isConditional
+    # so we should have nonlocal set via our describedBy patch
+    template = """{% set describedBy = "" %}{% set isConditional = false %}"""
     assert "{%- set nonlocal = namespace() -%}" in njk_to_j2(template)
 
 
@@ -183,7 +185,6 @@ def test_patches_isConditional_to_set_nonlocal():
         njk_to_j2(template)
         ==
 """
-{%- set nonlocal = namespace() -%}
 {% set nonlocal.isConditional = false %}
 {% set nonlocal.isConditional = true %}
 {%- if nonlocal.isConditional %} data-module="radios"{% endif -%}>


### PR DESCRIPTION
In the Radios and Checkboxes component, isConditional is set in a `{% for %}` block, so needs to be namespaced.

```{% set isConditional = false %}
{% for item in params.items %}
  {% if item.conditional %}
    {% set isConditional = true %}
  {% endif %}
{% endfor %}
```

This PR does that.