### PR TITLE
Fix cell attributes iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bugfixes
+
+* Fix Table `for attribute, value` iteration ([#60](https://github.com/alphagov/govuk-frontend-jinja/pull/60))
+
 ## 2020-09-25 version 0.5.6-alpha
 
 ### Bugfixes

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -60,7 +60,14 @@ def njk_to_j2(template):
     # In Python the default iterator for a dict is .keys(), but we want .items().
     # This only works because our undefined implements .items().
     template = template.replace("for attribute, value in item.attributes",
-                                "for attribute, value in item.attributes.items()")
+                                "for attribute, value in item.attributes.items()")    
+    
+    # The attributes field of a govukTable cell is supposed to be a dictionary,
+    # and in the template for the table component the keys and values are iterated.
+    # In Python the default iterator for a dict is .keys(), but we want .items().
+    # This only works because our undefined implements .items().
+    template = template.replace("for attribute, value in cell.attributes",
+                                "for attribute, value in cell.attributes.items()")
 
 
     # Some templates try to set a variable in an outer block, which is not

--- a/tests/components/table/test_table.py
+++ b/tests/components/table/test_table.py
@@ -11,3 +11,8 @@ def test_table_with_head(env, similar, template, expected):
 def test_table_with_head_and_caption(env, similar, template, expected):
     template = env.from_string(template)
     assert similar(template.render(), expected)
+
+
+def test_table_with_cell_attributes(env, similar, template, expected):
+    template = env.from_string(template)
+    assert similar(template.render(), expected)

--- a/tests/components/table/test_table_with_cell_attributes.t.html
+++ b/tests/components/table/test_table_with_cell_attributes.t.html
@@ -1,0 +1,47 @@
+{% from "table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  "rows": [
+    [
+      {
+        "text": "January"
+      },
+      {
+        "text": "£85",
+        "format": "numeric",
+        "attributes": {"data-currency": "pound"}
+      },
+      {
+        "text": "£95",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "February",
+        "attributes": {"data-month": "02"}
+      },
+      {
+        "text": "£75",
+        "format": "numeric"
+      },
+      {
+        "text": "£55",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "March"
+      },
+      {
+        "text": "£165",
+        "format": "numeric"
+      },
+      {
+        "text": "£125",
+        "format": "numeric"
+      }
+    ]
+  ]
+}) }}

--- a/tests/components/table/test_table_with_cell_attributes.x.html
+++ b/tests/components/table/test_table_with_cell_attributes.x.html
@@ -1,0 +1,19 @@
+<table class="govuk-table">
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">January</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric" data-currency="pound">£85</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">£95</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell" data-month="02">February</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">£75</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">£55</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">March</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">£165</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">£125</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -100,6 +100,14 @@ def test_patches_iteration_of_item_attributes():
     )
 
 
+def test_patches_iteration_of_cell_attributes():
+    assert (
+        njk_to_j2("{%- for attribute, value in cell.attributes %}{% endfor -%}")
+        ==
+        "{%- for attribute, value in cell.attributes.items() %}{% endfor -%}"
+    )
+
+
 @pytest.mark.parametrize("template", (
     """\n    {% set describedBy = "" %}""",
     """\n    {% set describedBy = params.describedBy if params.describedBy else "" %}""",


### PR DESCRIPTION
Similarly to other components with an iteration through `attributes`, we need to allow for table cells to properly iterate attributes using `.items()`.