### PR TITLE
Simplify attribute, value iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bugfixes
+
+* Fix Summary List `for attribute, value` iteration ([#62](https://github.com/alphagov/govuk-frontend-jinja/pull/62))
+
 ## 2020-12-14 version 0.5.7-alpha
 
 ### Bugfixes

--- a/govuk_frontend_jinja/templates.py
+++ b/govuk_frontend_jinja/templates.py
@@ -48,27 +48,19 @@ def njk_to_j2(template):
     template = template.replace("macro govukFieldset(params)",
                                 "macro govukFieldset(params, caller=none)")
 
-    # The attributes field of params for govukInput is supposed to be a dictionary,
-    # and in the template for the input component the keys and values are iterated.
-    # In Python the default iterator for a dict is .keys(), but we want .items().
-    # This only works because our undefined implements .items().
-    template = template.replace("for attribute, value in params.attributes",
-                                "for attribute, value in params.attributes.items()")
-
-    # The attributes field of a govukCheckbox item is supposed to be a dictionary,
-    # and in the template for the checkbox component the keys and values are iterated.
-    # In Python the default iterator for a dict is .keys(), but we want .items().
-    # This only works because our undefined implements .items().
-    template = template.replace("for attribute, value in item.attributes",
-                                "for attribute, value in item.attributes.items()")    
-    
-    # The attributes field of a govukTable cell is supposed to be a dictionary,
-    # and in the template for the table component the keys and values are iterated.
-    # In Python the default iterator for a dict is .keys(), but we want .items().
-    # This only works because our undefined implements .items().
-    template = template.replace("for attribute, value in cell.attributes",
-                                "for attribute, value in cell.attributes.items()")
-
+    # Many components feature an attributes field, which is supposed to be
+    # a dictionary. In the template for these components, the keys and values
+    # are iterated. In Python, the default iterator for a dict is .keys(), but
+    # we want .items().
+    # This only works because our undefined implements .items()
+    # We've tested this explicitly with: govukInput, govukCheckbox, govukTable,
+    # govukSummaryList
+    template = re.sub(
+        r"for attribute, value in (params|item|cell|action).attributes",
+        r"for attribute, value in \1.attributes.items()",
+        template,
+        flags=re.M
+    )
 
     # Some templates try to set a variable in an outer block, which is not
     # supported in Jinja. We create a namespace in those templates to get

--- a/tests/components/summary_list/test_summary_list_with_actions.t.html
+++ b/tests/components/summary_list/test_summary_list_with_actions.t.html
@@ -14,7 +14,8 @@
           {
             'href': "#",
             'text': "Change",
-            'visuallyHiddenText': "name"
+            'visuallyHiddenText': "name",
+            'attributes': {'data-test': "value"}
           }
         ]
       }

--- a/tests/components/summary_list/test_summary_list_with_actions.x.html
+++ b/tests/components/summary_list/test_summary_list_with_actions.x.html
@@ -9,7 +9,7 @@
         Sarah Philips
       </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="#" data-test="value">
                 Change<span class="govuk-visually-hidden"> name</span>
             </a>
         </dd>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -84,27 +84,17 @@ def test_patches_govuk_fieldset_definition():
     )
 
 
-def test_patches_iteration_of_params_attributes():
+@pytest.mark.parametrize("object", (
+    "params",
+    "item",
+    "cell",
+    "action"
+))
+def test_patches_iteration_of_attributes(object):
     assert (
-        njk_to_j2("{%- for attribute, value in params.attributes %}{% endfor -%}")
+        njk_to_j2("{%- for attribute, value in " f"{object}" ".attributes %}{% endfor -%}")
         ==
-        "{%- for attribute, value in params.attributes.items() %}{% endfor -%}"
-    )
-
-
-def test_patches_iteration_of_item_attributes():
-    assert (
-        njk_to_j2("{%- for attribute, value in item.attributes %}{% endfor -%}")
-        ==
-        "{%- for attribute, value in item.attributes.items() %}{% endfor -%}"
-    )
-
-
-def test_patches_iteration_of_cell_attributes():
-    assert (
-        njk_to_j2("{%- for attribute, value in cell.attributes %}{% endfor -%}")
-        ==
-        "{%- for attribute, value in cell.attributes.items() %}{% endfor -%}"
+        "{%- for attribute, value in " f"{object}" ".attributes.items() %}{% endfor -%}"
     )
 
 


### PR DESCRIPTION
We currently add a check if and when we encounter a `for attribute, value in` iteration.

This PR simplifies this a bit.

I've left the `(foo|bar)` structure to make it explicit what we've added. However, even
in those cases we have not explicitly checked ALL uses of that change.

This may be _good enough_ until we deprecate this repo - alternatively, we will have to create explicit test cases for each example of this pattern in govuk-frontend: https://github.com/alphagov/govuk-frontend/search?l=HTML%2BDjango&q=for+attribute%2C+value+in

This PR adds one of those specific tests - for summary list actions.