### PR TITLE
replace travis CI with github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Run tests
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+    
+      - name: Install tox
+        run: pip install tox
+      
+      - name: Run tests
+        run: tox -- -ra

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-  - "3.6"
-install:
-  - pip install tox-travis
-script:
-  - tox -- -ra

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 
-GOV.UK Frontend (Jinja) ·
-[![Build Status](https://travis-ci.com/alphagov/govuk-frontend-jinja.svg?branch=master)](https://travis-ci.com/alphagov/govuk-frontend-jinja)
-=========================
+GOV.UK Frontend (Jinja)
+=======================
 
 This Python package includes classes and modules to make it easier to use the
 [GOV.UK Frontend] in your [Jinja2][Jinja]-powered Python web app.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py36
-
 [testenv]
 whitelist_externals = sh
 extras =


### PR DESCRIPTION
https://trello.com/c/jfRAF4AR/1562-migrate-govuk-frontend-jinja-from-travis-to-github-actions

This app was missed when migrating from Travis CI from Github Actions.